### PR TITLE
Added insert & update.

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -1,0 +1,77 @@
+// Copyright 2020 The GoQueryBuilder Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package querybuilder
+
+import (
+	"reflect"
+	"strings"
+)
+
+// Insert
+//
+// Sets the insert table statement to the table name.
+func (s *Sqlbuilder) Insert(table string) *Sqlbuilder {
+	s.insertStmt = table
+	return s
+}
+
+// Update
+//
+// Sets the update table statement to the table name.
+func (s *Sqlbuilder) Update(table string) *Sqlbuilder {
+	s.updateStmt = table
+	return s
+}
+
+// Column
+//
+// Adds a string column for INSERT & UPDATE statements.
+func (s *Sqlbuilder) Column(column string, value interface{}) *Sqlbuilder {
+	val, ok := printInterface(reflect.ValueOf(value))
+	if !ok {
+		return s
+	}
+	col := [2]string{column, val}
+	s.columns = append(s.columns, col)
+	return s
+}
+
+// buildUpdate
+//
+// Creates the insert statement when `Build()` is called.
+func (s *Sqlbuilder) constructUpdate() string {
+	var set string
+	for _, v := range s.columns {
+		set += v[0] + "=" + v[1] + ", "
+	}
+
+	set = strings.TrimSuffix(set, ", ")
+
+	// TODO: This should be within a `Where` function.
+	var where string
+	if s.whereStmt != `` {
+		where = ` WHERE ` + strings.TrimSuffix(s.whereStmt, ` AND `) + ` `
+	}
+
+	return "UPDATE `" + s.updateStmt + "` SET " + set + where
+}
+
+// buildInsert
+//
+// Creates the update statement when `Build()` is called.
+func (s *Sqlbuilder) constructInsert() string {
+	var cols string
+	var values string
+
+	for _, v := range s.columns {
+		cols += v[0] + ", "
+		values += v[1] + ", "
+	}
+
+	cols = strings.TrimSuffix(cols, ", ")
+	values = strings.TrimSuffix(values, ", ")
+
+	return "INSERT INTO `" + s.insertStmt + "` (" + cols + ") VALUES (" + values + ")"
+}

--- a/insert.go
+++ b/insert.go
@@ -31,7 +31,7 @@ func (s *Sqlbuilder) Update(table string) *Sqlbuilder {
 func (s *Sqlbuilder) Column(column string, value interface{}) *Sqlbuilder {
 	val, ok := printInterface(reflect.ValueOf(value))
 	if !ok {
-		return s
+		val = "NULL"
 	}
 	col := [2]string{column, val}
 	s.columns = append(s.columns, col)

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -1,3 +1,7 @@
+// Copyright 2020 The GoQueryBuilder Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package querybuilder
 
 import (
@@ -20,6 +24,12 @@ type Sqlbuilder struct {
 	limitStmt string
 	offsetStmt string
 	orderbyStmt string
+	// Insert table
+	insertStmt     string
+	// Update table
+	updateStmt     string
+	// Slice of columns, key value for updates & inserts.
+	columns        [][2]string
 	Dialect string //Can be postgres, mysql or (more to come)
 }
 
@@ -242,6 +252,16 @@ func (s *Sqlbuilder) Exists() string {
 
 func (s *Sqlbuilder) Build() string {
 
+	// insert
+	if s.insertStmt != `` {
+		return s.constructInsert()
+	}
+
+	// update
+	if s.updateStmt != `` {
+		return s.constructUpdate()
+	}
+
 	//build selects
 	if s.deletefromStmt == `` {
 		if s.selectStmt == `` {
@@ -291,7 +311,6 @@ func (s *Sqlbuilder) Build() string {
 	return returnString
 }
 
-
 func (s *Sqlbuilder) BuildInsert(table string, data interface{}, additionalQuery ...string) (string, error) {
 	dbCols, dbVals, err := mapStruct(data)
 	if err != nil {
@@ -307,7 +326,6 @@ func (s *Sqlbuilder) BuildInsert(table string, data interface{}, additionalQuery
 
 	return sql, nil
 }
-
 
 func (s *Sqlbuilder) BuildUpdate(table string, data interface{}, additionalQuery string) (string, error) {
 
@@ -337,148 +355,4 @@ func (s *Sqlbuilder) BuildUpdate(table string, data interface{}, additionalQuery
 	}
 
 	return sql, errors.New("sql build failed")
-}
-
-
-
-
-
-/**
-Helpers
-*/
-
-func (s *Sqlbuilder) formatSchema (schema string) string {
-	schemaParts := strings.Split(schema, ".")
-	finalSchemaStmt := ``
-
-	var dialectFormat string
-
-	switch strings.ToLower(s.Dialect) {
-	case "postgres":
-		dialectFormat = `"`
-		break
-	case "mysql":
-		dialectFormat = "`"
-		break
-	default:
-		dialectFormat = `"`
-	}
-
-
-	for _, v := range schemaParts {
-		if v == `*` {
-			finalSchemaStmt += `*`
-		}else{
-			part := strings.TrimSpace(v)
-			if string(part[0]) == dialectFormat && string(part[len(part) - 1]) == dialectFormat {
-				finalSchemaStmt += part + `.`
-			}else{
-				finalSchemaStmt += dialectFormat + part + dialectFormat + `.`
-			}
-
-		}
-	}
-
-	return strings.TrimSuffix(finalSchemaStmt, `.`)
-}
-
-func (s *Sqlbuilder) formatJoinOn (joinStmt string) string {
-	joinParts := strings.Split(joinStmt, "=")
-	finalJoinStmt := ``
-
-	for _, v := range joinParts {
-		finalJoinStmt += s.formatSchema(v) + ` = `
-	}
-
-	return strings.TrimSuffix(finalJoinStmt, ` = `)
-}
-
-var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
-var matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
-
-func toSnakeCase(str string) string {
-	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
-	snake  = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
-	return strings.ToLower(snake)
-}
-
-func mapStruct (data interface{}) (dbCols []string, dbVals []string, error error){
-	fields := reflect.TypeOf(data)
-	values := reflect.ValueOf(data)
-
-	num := fields.NumField()
-
-	for i := 0; i < num; i++ {
-		field := fields.Field(i)
-		value := values.Field(i)
-
-		val, exists := field.Tag.Lookup("sqlb")
-
-		if exists {
-			dbCols = append(dbCols, "\"" + val + "\"")
-		}else{
-			dbCols = append(dbCols,  "\"" + toSnakeCase(field.Name)  + "\"")
-		}
-
-		var v string
-
-		v, ok := printInterface(value)
-		if !ok {
-			return dbCols, dbVals, errors.New("type: " + value.Kind().String() + " unsupported")
-		}
-		dbVals = append(dbVals, v)
-	}
-
-	return dbCols, dbVals, nil
-}
-
-func printInterface(value reflect.Value) (string, bool) {
-	var v string
-
-	switch value.Kind() {
-	case reflect.String:
-		v = "'" + sanitiseString(value.String()) + "'"
-	case reflect.Int:
-		v = strconv.FormatInt(value.Int(), 10)
-	case reflect.Int8:
-		v = strconv.FormatInt(value.Int(), 10)
-	case reflect.Int32:
-		v = strconv.FormatInt(value.Int(), 10)
-	case reflect.Int64:
-		v = strconv.FormatInt(value.Int(), 10)
-	case reflect.Float64:
-		v = fmt.Sprintf("%f", value.Float())
-	case reflect.Float32:
-		v = fmt.Sprintf("%f", value.Float())
-	case reflect.Bool:
-		if value.Bool(){
-			v = "TRUE"
-		}else{
-			v = "FALSE"
-		}
-	default:
-		return "", false
-	}
-
-	return v, true
-}
-
-func sanitiseString(str string) string {
-
-	if len(str) > 0 {
-		rebuildSingles := false
-
-		if string(str[0]) == "'" && string(str[len(str)-1]) == "'" {
-			rebuildSingles = true
-		}
-
-		str = strings.TrimSuffix(strings.TrimPrefix(str, "'"), "'")
-		str = strings.ReplaceAll(str, "'", "''")
-
-		if rebuildSingles {
-			str = "'" + str + "'"
-		}
-	}
-
-	return str
 }

--- a/querybuilder.go
+++ b/querybuilder.go
@@ -245,7 +245,8 @@ func (s *Sqlbuilder) Count() string {
 func (s *Sqlbuilder) Exists() string {
 	sqlquery := s.Build()
 
-	existsQuery := `SELECT EXISTS (` + sqlquery + `)`
+	q := strings.TrimSuffix(sqlquery, " ")
+	existsQuery := `SELECT EXISTS (` + q + `)`
 
 	return existsQuery
 }

--- a/tags.go
+++ b/tags.go
@@ -1,0 +1,44 @@
+// Copyright 2020 The GoQueryBuilder Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package querybuilder
+
+import (
+	"reflect"
+	"strings"
+)
+
+// TODO: Temporary placeholder for struct tags.
+
+const (
+	tagName    = "sqlb"
+	skipAll    = "skipAll"
+	createTime = "autoCreateTime"
+	updateTime = "autoUpdateTime"
+)
+
+func getTags(field reflect.StructField) (string, bool) {
+	return field.Tag.Lookup(tagName)
+}
+
+func splitTags(str string) []string {
+	return strings.Split(str, ",")
+}
+
+func isSkipped(tags []string) bool {
+	for _, v := range tags {
+		if v == skipAll {
+			return true
+		}
+	}
+	return false
+}
+
+func isAutoCreateTime(value string) bool {
+	return strings.Contains(value, createTime)
+}
+
+func isAutoUpdateTime(value string) bool {
+	return strings.Contains(value, updateTime)
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,163 @@
+// Copyright 2020 The GoQueryBuilder Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package querybuilder
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+/**
+Helpers
+*/
+
+func (s *Sqlbuilder) formatSchema (schema string) string {
+	schemaParts := strings.Split(schema, ".")
+	finalSchemaStmt := ``
+
+	var dialectFormat string
+
+	switch strings.ToLower(s.Dialect) {
+	case "postgres":
+		dialectFormat = `"`
+		break
+	case "mysql":
+		dialectFormat = "`"
+		break
+	default:
+		dialectFormat = `"`
+	}
+
+
+	for _, v := range schemaParts {
+		if v == `*` {
+			finalSchemaStmt += `*`
+		}else{
+			part := strings.TrimSpace(v)
+			if string(part[0]) == dialectFormat && string(part[len(part) - 1]) == dialectFormat {
+				finalSchemaStmt += part + `.`
+			}else{
+				finalSchemaStmt += dialectFormat + part + dialectFormat + `.`
+			}
+
+		}
+	}
+
+	return strings.TrimSuffix(finalSchemaStmt, `.`)
+}
+
+func (s *Sqlbuilder) formatJoinOn (joinStmt string) string {
+	joinParts := strings.Split(joinStmt, "=")
+	finalJoinStmt := ``
+
+	for _, v := range joinParts {
+		finalJoinStmt += s.formatSchema(v) + ` = `
+	}
+
+	return strings.TrimSuffix(finalJoinStmt, ` = `)
+}
+
+var matchFirstCap = regexp.MustCompile("(.)([A-Z][a-z]+)")
+var matchAllCap   = regexp.MustCompile("([a-z0-9])([A-Z])")
+
+func toSnakeCase(str string) string {
+	snake := matchFirstCap.ReplaceAllString(str, "${1}_${2}")
+	snake  = matchAllCap.ReplaceAllString(snake, "${1}_${2}")
+	return strings.ToLower(snake)
+}
+
+func mapStruct (data interface{}) (dbCols []string, dbVals []string, error error){
+	fields := reflect.TypeOf(data)
+	values := reflect.ValueOf(data)
+
+	num := fields.NumField()
+
+	for i := 0; i < num; i++ {
+		field := fields.Field(i)
+		value := values.Field(i)
+
+		val, exists := field.Tag.Lookup("sqlb")
+
+		if exists {
+			dbCols = append(dbCols, "\"" + val + "\"")
+		}else{
+			dbCols = append(dbCols,  "\"" + toSnakeCase(field.Name)  + "\"")
+		}
+
+		var v string
+
+		v, ok := printInterface(value)
+		if !ok {
+			return dbCols, dbVals, errors.New("type: " + value.Kind().String() + " unsupported")
+		}
+		dbVals = append(dbVals, v)
+	}
+
+	return dbCols, dbVals, nil
+}
+
+func printInterface(value reflect.Value) (string, bool) {
+	var v string
+
+	switch value.Kind() {
+	case reflect.String:
+		v = "'" + sanitiseString(value.String()) + "'"
+	case reflect.Int:
+		v = strconv.FormatInt(value.Int(), 10)
+	case reflect.Int8:
+		v = strconv.FormatInt(value.Int(), 10)
+	case reflect.Int32:
+		v = strconv.FormatInt(value.Int(), 10)
+	case reflect.Int64:
+		v = strconv.FormatInt(value.Int(), 10)
+	case reflect.Float64:
+		v = fmt.Sprintf("%f", value.Float())
+	case reflect.Float32:
+		v = fmt.Sprintf("%f", value.Float())
+	case reflect.Bool:
+		if value.Bool(){
+			v = "TRUE"
+		}else{
+			v = "FALSE"
+		}
+	default:
+		return "", false
+	}
+
+	// Sanity checking
+	if v == "'?'" {
+		v = "?"
+	}
+
+	if v == "'NOW()'" {
+		v = "NOW()"
+	}
+
+	return v, true
+}
+
+func sanitiseString(str string) string {
+
+	if len(str) > 0 {
+		rebuildSingles := false
+
+		if string(str[0]) == "'" && string(str[len(str)-1]) == "'" {
+			rebuildSingles = true
+		}
+
+		str = strings.TrimSuffix(strings.TrimPrefix(str, "'"), "'")
+		str = strings.ReplaceAll(str, "'", "''")
+
+		if rebuildSingles {
+			str = "'" + str + "'"
+		}
+	}
+
+	return str
+}

--- a/util.go
+++ b/util.go
@@ -120,6 +120,20 @@ func printInterface(value reflect.Value) (string, bool) {
 		v = fmt.Sprintf("%f", value.Float())
 	case reflect.Float32:
 		v = fmt.Sprintf("%f", value.Float())
+	case reflect.Slice:
+		v = fmt.Sprintf("%v", value)
+	case reflect.Array:
+		v = fmt.Sprintf("%v", value)
+	case reflect.Ptr:
+		if value.IsNil() {
+			v = "NULL"
+		} else {
+			val, ok := printInterface(reflect.ValueOf(value.Elem().Interface()))
+			if !ok {
+				return "", false
+			}
+			return val, true
+		}
 	case reflect.Bool:
 		if value.Bool(){
 			v = "TRUE"


### PR DESCRIPTION
@KirksFletcher summary of PR:

**Note:** Everything is backwards compatible.

## Insert & Update Raw 

Added `Insert` and `Update` raw functions for building out queries without the use of reflect. For example:

```go
 	q := s.Builder().Update(TableName).
		Column("slug", c.Slug).
		Column("name", c.Name).
		Column("description", c.Description).
		Column("parent_id", c.ParentId).
		Column("resource", c.Resource).
		Column("archive_id", c.ArchiveId).
		Where("id", "=", c.Id).
		Build()`
```

Likewise with `Insert`

```go
 	q := s.Builder().Insert(TableName).
		Column("slug", c.Slug) //etc etc
```

## Checking on `PrintInterface`

Added the ability to pass arguments (if necessary for inserts & updates) i.e generating a new UUID and generating timestamps.

```
	// Sanity checking
	if v == "'?'" {
		v = "?"
	}

	if v == "'NOW()'" {
		v = "NOW()"
	}
```

## Tags

Started the work on struct tags for the following:

- `skip`, `skipUpdate`, `skipCreate`

## Files

Separated util functions into separate file.
